### PR TITLE
enable statsd other containers

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,6 +23,10 @@ services:
     depends_on:
       ai:
         condition: service_completed_successfully
+      worker:
+        condition: service_started
+      redis:
+        condition: service_started
     ports:
       - "5001:5000"
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,8 @@ services:
     depends_on:
       app:
         condition: service_completed_successfully
+      api:
+        condition: service_started
     restart: always
 
   ai:
@@ -41,6 +43,12 @@ services:
     depends_on:
       ai:
         condition: service_completed_successfully
+      worker:
+        condition: service_started
+      redis:
+        condition: service_started
+      datadog-agent:
+        condition: service_started
     volumes:
       - lib:/libvol
       - ./api/src:/api/src
@@ -104,6 +112,9 @@ services:
       - DD_APM_ENABLED=true
       - DD_LOGS_ENABLED=true
       - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
+      - DD_APM_NON_LOCAL_TRAFFIC=true
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+      - DD_USE_DOGSTATSD=true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     restart: always


### PR DESCRIPTION
Adds env vars to the datadog-agent container so that it listens to statsd data from the api container.